### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checkdb.yml
+++ b/.github/workflows/checkdb.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *'  # Run at 00:00 UTC every Monday
   workflow_dispatch:  # Allows manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   update-projects:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Uraniumking007/bhaveshpdev-new/security/code-scanning/2](https://github.com/Uraniumking007/bhaveshpdev-new/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow steps, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `update-projects` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
